### PR TITLE
feat: 支持复制时自动上传本地图片到 GitHub CDN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,15 @@ VITE_APP_URL=https://bm.md
 # ANALYTICS_SCRIPT_URL=https://button.click/api/script.js
 # ANALYTICS_SITE_ID=a2f02dd2e67d
 
+# GitHub 图床配置（用于一键上传本地图片到 GitHub CDN）
+# 需要 GitHub Personal Access Token（Settings → Developer settings → Personal access tokens → Fine-grained tokens）
+# Token 权限: Contents: Read and write
+GITHUB_TOKEN=
+GITHUB_OWNER=
+GITHUB_REPO=
+# GITHUB_BRANCH=main
+
+# S3 兼容存储配置
 S3_ENDPOINT=https://s3.us-west-001.backblazeb2.com
 S3_BUCKET=some-temp-files
 S3_ACCESS_KEY_ID=0017333c2416

--- a/src/components/dialog/image-upload-dialog.tsx
+++ b/src/components/dialog/image-upload-dialog.tsx
@@ -1,0 +1,82 @@
+import { ImageUp, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useImageUploadStore } from '@/stores/image-upload'
+
+export function ImageUploadDialog() {
+  const images = useImageUploadStore(state => state.images)
+  const isOpen = useImageUploadStore(state => state.isOpen)
+  const isUploading = useImageUploadStore(state => state.isUploading)
+  const confirmUpload = useImageUploadStore(state => state.confirmUpload)
+  const cancelUpload = useImageUploadStore(state => state.cancelUpload)
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isUploading) {
+          cancelUpload()
+        }
+      }}
+    >
+      <DialogContent showCloseButton={!isUploading}>
+        <DialogHeader>
+          <DialogTitle>发现本地图片</DialogTitle>
+          <DialogDescription>
+            检测到
+            {' '}
+            {images.length}
+            {' '}
+            张本地图片，确认上传到 GitHub CDN 后，将自动替换 Markdown 中的链接为加速地址。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-48 overflow-y-auto">
+          {images.map((img, index) => (
+            <div
+              key={index}
+              className={`
+                flex items-center gap-2 rounded px-2 py-1 text-xs
+                text-muted-foreground
+                hover:bg-accent
+              `}
+            >
+              <ImageUp className="size-3 shrink-0" />
+              <span className="truncate">{img.filename}</span>
+              <code className={`
+                ml-auto shrink-0 truncate text-[10px] text-muted-foreground/60
+              `}
+              >
+                {img.url}
+              </code>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            disabled={isUploading}
+            onClick={cancelUpload}
+          >
+            取消
+          </Button>
+          <Button
+            onClick={confirmUpload}
+            disabled={isUploading}
+          >
+            {isUploading && <Loader2 className="size-3 animate-spin" />}
+            {isUploading ? '上传中...' : '确认上传'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -9,11 +9,11 @@
 function getPrivate(key: string): string | undefined {
   // 优先从 EdgeKV 缓存获取
   if (globalThis.edgeKVCache && key in globalThis.edgeKVCache) {
-    return globalThis.edgeKVCache[key] as string
+    return (globalThis.edgeKVCache[key] as string).trim()
   }
   // 从 process.env 获取
   if (typeof process !== 'undefined' && process.env?.[key]) {
-    return process.env[key]
+    return process.env[key]!.trim()
   }
   return undefined
 }
@@ -30,6 +30,12 @@ export const env = {
   get S3_SECRET_ACCESS_KEY() { return getPrivate('S3_SECRET_ACCESS_KEY') },
   get S3_REGION() { return getPrivate('S3_REGION') },
   get S3_PUBLIC_BASE_URL() { return getPrivate('S3_PUBLIC_BASE_URL') },
+
+  // GitHub 图床配置
+  get GITHUB_TOKEN() { return getPrivate('GITHUB_TOKEN') },
+  get GITHUB_OWNER() { return getPrivate('GITHUB_OWNER') },
+  get GITHUB_REPO() { return getPrivate('GITHUB_REPO') },
+  get GITHUB_BRANCH() { return getPrivate('GITHUB_BRANCH') },
 
   // DC 图床配置
   get DC_UPLOAD_URL() { return getPrivate('DC_UPLOAD_URL') },

--- a/src/lib/actions/check-local-images.ts
+++ b/src/lib/actions/check-local-images.ts
@@ -1,0 +1,74 @@
+export interface LocalImageRef {
+  fullMatch: string
+  url: string
+  filename: string
+  alt?: string
+}
+
+const LOCAL_IMAGE_RE = /!\[([^\]]*)\]\(([^)]+)\)/g
+
+function isLocalUrl(url: string): boolean {
+  const trimmed = url.trim()
+  if (!trimmed || trimmed.startsWith('#'))
+    return false
+
+  // 有显式协议头
+  if (/^[a-z][a-z0-9+\-.]*:/i.test(trimmed)) {
+    // 仅 localhost / 127.0.0.1 算本地
+    return /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?\//i.test(trimmed)
+  }
+
+  // data: 或类似协议无前导 // → 非本地
+  if (/^data:/i.test(trimmed))
+    return false
+
+  // 无协议头 → 相对路径或绝对服务器路径，均视为本地
+  return true
+}
+
+function extractFilename(url: string): string {
+  const clean = url.replace(/[?#].*$/, '').replace(/\/$/, '')
+  const segments = clean.split(/[/\\]/)
+  const last = segments.at(-1)
+  if (last && last.includes('.')) {
+    return decodeURIComponent(last)
+  }
+  return 'image.png'
+}
+
+export function findLocalImagesInMarkdown(markdown: string): LocalImageRef[] {
+  const results: LocalImageRef[] = []
+
+  LOCAL_IMAGE_RE.lastIndex = 0
+
+  for (let match = LOCAL_IMAGE_RE.exec(markdown); match; match = LOCAL_IMAGE_RE.exec(markdown)) {
+    const alt = match[1]
+    const url = match[2].trim()
+
+    if (isLocalUrl(url)) {
+      results.push({
+        fullMatch: match[0],
+        url,
+        filename: extractFilename(url),
+        alt: alt || undefined,
+      })
+    }
+  }
+
+  return results
+}
+
+export function replaceImageUrlsInMarkdown(
+  markdown: string,
+  replacements: Map<string, string>,
+): string {
+  let result = markdown
+
+  for (const [originalUrl, cdnUrl] of replacements) {
+    const escapedUrl = originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`(?<=\\()${escapedUrl}(?=\\s*["')])`, 'g')
+    result = result.replace(regex, cdnUrl)
+  }
+
+  return result
+}

--- a/src/lib/actions/copy-platform.ts
+++ b/src/lib/actions/copy-platform.ts
@@ -3,6 +3,12 @@ import { toast } from 'sonner'
 import { platformConfig } from '@/config'
 import { trackEvent } from '@/lib/analytics'
 import { copyHtml } from '@/lib/clipboard'
+import { uploadLocalImages } from '@/services/upload-local-images'
+import { useEditorStore } from '@/stores/editor'
+import { useFilesStore } from '@/stores/files'
+import { useImageUploadStore } from '@/stores/image-upload'
+import { usePreviewStore } from '@/stores/preview'
+import { findLocalImagesInMarkdown, replaceImageUrlsInMarkdown } from './check-local-images'
 
 const developingPlatforms: SupportedPlatform[] = ['zhihu', 'juejin']
 
@@ -15,6 +21,40 @@ interface CopyPlatformOptions {
   infographicPalette: string
   source: 'button' | 'menu'
   getHtml: () => Promise<string>
+}
+
+async function renderAndCopy(
+  markdown: string,
+  platform: SupportedPlatform,
+  config: { successMessage: string },
+  source: string,
+  opts: { markdownStyle: string, codeTheme: string, mermaidTheme: string, infographicTheme: string, infographicPalette: string },
+) {
+  const { getMarkdownLocaleTexts } = await import('@/lib/locale')
+  const { markdown: md } = await import('@/lib/markdown/browser')
+  const result = await md.render({
+    markdown,
+    markdownStyle: opts.markdownStyle,
+    codeTheme: opts.codeTheme,
+    enableFootnoteLinks: useEditorStore.getState().enableFootnoteLinks,
+    openLinksInNewWindow: useEditorStore.getState().openLinksInNewWindow,
+    platform,
+    ...getMarkdownLocaleTexts(),
+  })
+
+  if (!result.result.trim()) {
+    toast.error('没有可复制的内容')
+    return
+  }
+
+  const success = await copyHtml(result.result)
+  if (success) {
+    toast.success(config.successMessage)
+    trackEvent('copy', platform, source, opts)
+  }
+  else {
+    toast.error('复制失败')
+  }
 }
 
 export async function copyPlatform({
@@ -30,6 +70,63 @@ export async function copyPlatform({
   if (developingPlatforms.includes(platform)) {
     toast.info('功能开发中，敬请期待')
     return
+  }
+
+  const content = useFilesStore.getState().currentContent
+  const localImages = findLocalImagesInMarkdown(content)
+
+  if (localImages.length > 0) {
+    const confirmed = await useImageUploadStore.getState().showDialog(localImages)
+
+    if (confirmed) {
+      useImageUploadStore.setState({ isUploading: true })
+      try {
+        const results = await uploadLocalImages(
+          localImages.map(img => ({ url: img.url })),
+        )
+
+        const replacements = new Map<string, string>()
+        for (const r of results) {
+          if (r.cdnUrl) {
+            replacements.set(r.originalUrl, r.cdnUrl)
+          }
+        }
+
+        if (results.some(r => !r.cdnUrl)) {
+          const failed = results.filter(r => !r.cdnUrl).length
+          toast.warning(`${failed} 张图片上传失败，已跳过`)
+        }
+
+        if (replacements.size === 0) {
+          return
+        }
+
+        const newContent = replaceImageUrlsInMarkdown(content, replacements)
+        useFilesStore.getState().setCurrentContent(newContent)
+        usePreviewStore.getState().clearRenderedHtmlCache()
+
+        const config = platformConfig[platform]
+        await renderAndCopy(newContent, platform, config, source, {
+          markdownStyle,
+          codeTheme,
+          mermaidTheme,
+          infographicTheme,
+          infographicPalette,
+        })
+        return
+      }
+      catch (err) {
+        const message = err instanceof Error ? err.message : '上传失败'
+        toast.error(message)
+        return
+      }
+      finally {
+        useImageUploadStore.setState({ isUploading: false })
+      }
+    }
+    else {
+      return
+    }
   }
 
   const config = platformConfig[platform]

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as LayoutIndexRouteImport } from './routes/_layout.index'
 import { Route as ApiSplatRouteImport } from './routes/api.$'
 import { Route as LayoutAboutRouteImport } from './routes/_layout.about'
 import { Route as ApiUploadImageRouteImport } from './routes/api.upload.image'
+import { Route as ApiUploadGithubImagesRouteImport } from './routes/api.upload.github-images'
 import { Route as LayoutDocsSkillRouteImport } from './routes/_layout.docs.skill'
 import { Route as LayoutDocsMcpRouteImport } from './routes/_layout.docs.mcp'
 
@@ -53,6 +54,11 @@ const ApiUploadImageRoute = ApiUploadImageRouteImport.update({
   path: '/api/upload/image',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiUploadGithubImagesRoute = ApiUploadGithubImagesRouteImport.update({
+  id: '/api/upload/github-images',
+  path: '/api/upload/github-images',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LayoutDocsSkillRoute = LayoutDocsSkillRouteImport.update({
   id: '/docs/skill',
   path: '/docs/skill',
@@ -72,6 +78,7 @@ export interface FileRoutesByFullPath {
   '/api/$': typeof ApiSplatRoute
   '/docs/mcp': typeof LayoutDocsMcpRoute
   '/docs/skill': typeof LayoutDocsSkillRoute
+  '/api/upload/github-images': typeof ApiUploadGithubImagesRoute
   '/api/upload/image': typeof ApiUploadImageRoute
 }
 export interface FileRoutesByTo {
@@ -82,6 +89,7 @@ export interface FileRoutesByTo {
   '/': typeof LayoutIndexRoute
   '/docs/mcp': typeof LayoutDocsMcpRoute
   '/docs/skill': typeof LayoutDocsSkillRoute
+  '/api/upload/github-images': typeof ApiUploadGithubImagesRoute
   '/api/upload/image': typeof ApiUploadImageRoute
 }
 export interface FileRoutesById {
@@ -94,6 +102,7 @@ export interface FileRoutesById {
   '/_layout/': typeof LayoutIndexRoute
   '/_layout/docs/mcp': typeof LayoutDocsMcpRoute
   '/_layout/docs/skill': typeof LayoutDocsSkillRoute
+  '/api/upload/github-images': typeof ApiUploadGithubImagesRoute
   '/api/upload/image': typeof ApiUploadImageRoute
 }
 export interface FileRouteTypes {
@@ -106,6 +115,7 @@ export interface FileRouteTypes {
     | '/api/$'
     | '/docs/mcp'
     | '/docs/skill'
+    | '/api/upload/github-images'
     | '/api/upload/image'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -116,6 +126,7 @@ export interface FileRouteTypes {
     | '/'
     | '/docs/mcp'
     | '/docs/skill'
+    | '/api/upload/github-images'
     | '/api/upload/image'
   id:
     | '__root__'
@@ -127,6 +138,7 @@ export interface FileRouteTypes {
     | '/_layout/'
     | '/_layout/docs/mcp'
     | '/_layout/docs/skill'
+    | '/api/upload/github-images'
     | '/api/upload/image'
   fileRoutesById: FileRoutesById
 }
@@ -135,6 +147,7 @@ export interface RootRouteChildren {
   DocsRoute: typeof DocsRoute
   McpRoute: typeof McpRoute
   ApiSplatRoute: typeof ApiSplatRoute
+  ApiUploadGithubImagesRoute: typeof ApiUploadGithubImagesRoute
   ApiUploadImageRoute: typeof ApiUploadImageRoute
 }
 
@@ -189,6 +202,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiUploadImageRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/upload/github-images': {
+      id: '/api/upload/github-images'
+      path: '/api/upload/github-images'
+      fullPath: '/api/upload/github-images'
+      preLoaderRoute: typeof ApiUploadGithubImagesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_layout/docs/skill': {
       id: '/_layout/docs/skill'
       path: '/docs/skill'
@@ -228,6 +248,7 @@ const rootRouteChildren: RootRouteChildren = {
   DocsRoute: DocsRoute,
   McpRoute: McpRoute,
   ApiSplatRoute: ApiSplatRoute,
+  ApiUploadGithubImagesRoute: ApiUploadGithubImagesRoute,
   ApiUploadImageRoute: ApiUploadImageRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/_layout.tsx
+++ b/src/routes/_layout.tsx
@@ -1,6 +1,7 @@
 import { ClientOnly, createFileRoute, Outlet } from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { CommandPalette } from '@/components/command-palette'
+import { ImageUploadDialog } from '@/components/dialog/image-upload-dialog'
 import MarkdownEditor from '@/components/markdown/editor'
 import { FooterBar } from '@/components/markdown/footer-bar'
 import MarkdownPreviewer from '@/components/markdown/previewer'
@@ -36,6 +37,7 @@ function App() {
       <ClientOnly>
         <CommandPalette />
       </ClientOnly>
+      <ImageUploadDialog />
       <Outlet />
     </div>
   )

--- a/src/routes/api.upload.github-images.ts
+++ b/src/routes/api.upload.github-images.ts
@@ -1,0 +1,107 @@
+import process from 'node:process'
+import { createFileRoute } from '@tanstack/react-router'
+import * as z from 'zod'
+import { corsMiddleware } from '@/lib/middleware/cors'
+import { GitHubStorage, StorageError } from '@/storage'
+
+const imageSchema = z.object({
+  url: z.string().min(1),
+})
+
+const requestSchema = z.object({
+  images: z.array(imageSchema).min(1).max(50),
+})
+
+export const Route = createFileRoute('/api/upload/github-images')({
+  server: {
+    middleware: [corsMiddleware],
+    handlers: {
+      POST: async ({ request }) => {
+        try {
+          const body = await request.json() as unknown
+          const parsed = requestSchema.parse(body)
+
+          const storage = new GitHubStorage()
+          const results: Array<{ originalUrl: string, cdnUrl: string }> = []
+
+          for (const { url } of parsed.images) {
+            try {
+              const filename = url.split('/').at(-1) || 'image.png'
+              const decodedUrl = decodeURIComponent(url)
+
+              let filePath: string
+              const hasScheme = /^[a-z][a-z0-9+\-.]*:\/\//i.test(decodedUrl)
+
+              if (hasScheme) {
+                if (/^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?\//i.test(decodedUrl)) {
+                  const urlObj = new URL(decodedUrl)
+                  filePath = `.${urlObj.pathname}`
+                }
+                else {
+                  results.push({ originalUrl: url, cdnUrl: '' })
+                  continue
+                }
+              }
+              else if (decodedUrl.startsWith('/')) {
+                filePath = `.${decodedUrl}`
+              }
+              else if (/^[a-z]:\\/i.test(decodedUrl) || /^[a-z]:\//i.test(decodedUrl)) {
+                filePath = decodedUrl
+              }
+              else {
+                filePath = `./public/${decodedUrl}`
+              }
+
+              const fs = await import('node:fs')
+              const path = await import('node:path')
+              const absolutePath = path.resolve(process.cwd(), filePath)
+
+              if (!fs.existsSync(absolutePath)) {
+                results.push({ originalUrl: url, cdnUrl: '' })
+                continue
+              }
+
+              const fileBuffer = fs.readFileSync(absolutePath)
+
+              const uploadResult = await storage.upload({
+                file: fileBuffer,
+                filename,
+                contentType: 'image/png',
+              })
+
+              results.push({ originalUrl: url, cdnUrl: uploadResult.url })
+            }
+            catch {
+              results.push({ originalUrl: url, cdnUrl: '' })
+            }
+          }
+
+          return Response.json({ results })
+        }
+        catch (error) {
+          if (error instanceof StorageError) {
+            console.error(`GitHub upload error [${error.provider}]:`, error.message, error.cause)
+            return Response.json(
+              { error: 'GitHub 图床上传失败' },
+              { status: 500 },
+            )
+          }
+
+          console.error('GitHub upload error:', error)
+
+          if (error && typeof error === 'object' && 'issues' in error) {
+            return Response.json(
+              { error: '请求参数错误' },
+              { status: 400 },
+            )
+          }
+
+          return Response.json(
+            { error: '图片上传失败，请稍后重试' },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/services/upload-local-images.ts
+++ b/src/services/upload-local-images.ts
@@ -1,0 +1,31 @@
+import { apiFetch } from '@/lib/api'
+
+export interface GithubImageUploadRequest {
+  url: string
+}
+
+export interface GithubImageUploadResult {
+  originalUrl: string
+  cdnUrl: string
+}
+
+export interface GithubImageUploadResponse {
+  results: GithubImageUploadResult[]
+}
+
+export async function uploadLocalImages(
+  images: GithubImageUploadRequest[],
+): Promise<GithubImageUploadResult[]> {
+  try {
+    const response = await apiFetch<GithubImageUploadResponse>('/api/upload/github-images', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ images }),
+    })
+    return response.results
+  }
+  catch (error: any) {
+    const message = error?.data?.error || error?.message || '图片上传到 GitHub 失败'
+    throw new Error(message)
+  }
+}

--- a/src/storage/github-storage.ts
+++ b/src/storage/github-storage.ts
@@ -1,0 +1,115 @@
+'use server'
+
+import type { StorageProvider, UploadOptions, UploadResult } from './types'
+import { Buffer } from 'node:buffer'
+
+import { request as httpsRequest } from 'node:https'
+import { env } from '@/env'
+import { StorageError } from './types'
+
+function httpsFetch(url: string, options: {
+  method?: string
+  headers?: Record<string, string>
+  body?: string
+}): Promise<{ status: number, text: () => Promise<string> }> {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url)
+    const mod = httpsRequest
+
+    const req = mod(urlObj, {
+      method: options.method || 'GET',
+      headers: options.headers,
+    }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (chunk: Buffer) => chunks.push(chunk))
+      res.on('end', () => {
+        const body = Buffer.concat(chunks)
+        resolve({
+          status: res.statusCode || 0,
+          text: async () => body.toString('utf-8'),
+        })
+      })
+    })
+
+    req.on('error', reject)
+
+    if (options.body) {
+      req.write(options.body)
+    }
+    req.end()
+  })
+}
+
+export class GitHubStorage implements StorageProvider {
+  readonly type = 'github' as const
+
+  private token: string
+  private owner: string
+  private repo: string
+  private branch: string
+
+  constructor() {
+    const token = env.GITHUB_TOKEN
+    const owner = env.GITHUB_OWNER
+    const repo = env.GITHUB_REPO
+
+    console.info(`[GitHubStorage] token loaded: ${!!token}, len: ${token?.length ?? 0}, owner: ${owner}, repo: ${repo}, branch: ${env.GITHUB_BRANCH || 'main'}`)
+
+    if (!token || !owner || !repo) {
+      throw new StorageError('GitHub 凭证配置缺失（需要 GITHUB_TOKEN、GITHUB_OWNER、GITHUB_REPO）', 'github')
+    }
+
+    this.token = token
+    this.owner = owner
+    this.repo = repo
+    this.branch = env.GITHUB_BRANCH || 'main'
+  }
+
+  async upload(options: UploadOptions): Promise<UploadResult> {
+    const { file, filename } = options
+
+    try {
+      const buffer = Buffer.isBuffer(file) ? file : Buffer.from(new Uint8Array(await file.arrayBuffer()))
+      const content = buffer.toString('base64')
+
+      const timestamp = Date.now()
+      const safeName = filename.replace(/[^\w.-]/g, '_')
+      const path = `articles/${timestamp}-${safeName}`
+      const url = `https://api.github.com/repos/${this.owner}/${this.repo}/contents/${path}`
+
+      console.info(`[GitHubStorage] uploading: ${path}, size: ${buffer.length} bytes`)
+
+      const response = await httpsFetch(url, {
+        method: 'PUT',
+        headers: {
+          'Authorization': `Bearer ${this.token}`,
+          'Content-Type': 'application/json',
+          'Accept': 'application/vnd.github.v3+json',
+          'User-Agent': 'bm.md',
+        },
+        body: JSON.stringify({
+          message: `Upload image via bm.md: ${safeName}`,
+          content,
+          branch: this.branch,
+        }),
+      })
+
+      if (response.status < 200 || response.status >= 300) {
+        const errorText = await response.text()
+        console.error('[GitHubStorage] upload failed:', response.status, errorText)
+        console.error('[GitHubStorage] request URL:', url)
+        console.error('[GitHubStorage] token prefix:', `${this.token.slice(0, 12)}...`)
+        throw new StorageError(`上传失败: ${response.status}`, 'github')
+      }
+
+      const cdnUrl = `https://cdn.jsdelivr.net/gh/${this.owner}/${this.repo}@${this.branch}/${path}`
+      return { url: cdnUrl }
+    }
+    catch (error) {
+      if (error instanceof StorageError) {
+        throw error
+      }
+      throw new StorageError('上传过程发生错误', 'github', error)
+    }
+  }
+}

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -11,6 +11,7 @@ import { DCStorage } from './dc-storage'
 import { S3Storage } from './s3-storage'
 
 export { DCStorage } from './dc-storage'
+export { GitHubStorage } from './github-storage'
 export { S3Storage } from './s3-storage'
 export * from './types'
 

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,9 +1,10 @@
 /**
  * 存储服务类型定义
  */
+import type { Buffer } from 'node:buffer'
 
 /** 存储提供商类型 */
-export type StorageProviderType = 's3' | 'dc'
+export type StorageProviderType = 's3' | 'dc' | 'github'
 
 /** 上传结果 */
 export interface UploadResult {
@@ -12,8 +13,8 @@ export interface UploadResult {
 
 /** 上传选项 */
 export interface UploadOptions {
-  /** 文件内容 */
-  file: Blob
+  /** 文件内容 (Blob 用于浏览器端, Buffer 用于服务端) */
+  file: Blob | Buffer
   /** 文件名 */
   filename: string
   /** 文件 MIME 类型 */

--- a/src/stores/image-upload.ts
+++ b/src/stores/image-upload.ts
@@ -1,0 +1,40 @@
+import type { LocalImageRef } from '@/lib/actions/check-local-images'
+import { create } from 'zustand'
+
+interface ImageUploadState {
+  images: LocalImageRef[]
+  isOpen: boolean
+  isUploading: boolean
+  showDialog: (images: LocalImageRef[]) => Promise<boolean>
+  confirmUpload: () => void
+  cancelUpload: () => void
+}
+
+export const useImageUploadStore = create<ImageUploadState>(() => {
+  let resolveRef: ((value: boolean) => void) | null = null
+
+  return {
+    images: [],
+    isOpen: false,
+    isUploading: false,
+
+    showDialog: async (images: LocalImageRef[]) => {
+      useImageUploadStore.setState({ images, isOpen: true, isUploading: false })
+      return new Promise<boolean>((resolve) => {
+        resolveRef = resolve
+      })
+    },
+
+    confirmUpload: () => {
+      useImageUploadStore.setState({ isOpen: false })
+      resolveRef?.(true)
+      resolveRef = null
+    },
+
+    cancelUpload: () => {
+      useImageUploadStore.setState({ isOpen: false })
+      resolveRef?.(false)
+      resolveRef = null
+    },
+  }
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,6 @@
+import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
 import process from 'node:process'
 import tailwindcss from '@tailwindcss/vite'
 import { devtools } from '@tanstack/devtools-vite'
@@ -14,6 +16,36 @@ import { cssRawMinifyPlugin, fixNitroInlineDynamicImports, htmlRawMinifyPlugin, 
 import { appConfig } from './src/config/app'
 
 const require = createRequire(import.meta.url)
+
+function loadLocalGitHubEnv() {
+  const envPath = resolve(process.cwd(), '.env')
+  if (!existsSync(envPath))
+    return
+
+  const content = readFileSync(envPath, 'utf-8')
+  const keys = new Set(['GITHUB_TOKEN', 'GITHUB_OWNER', 'GITHUB_REPO', 'GITHUB_BRANCH'])
+
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#'))
+      continue
+
+    const equalIndex = line.indexOf('=')
+    if (equalIndex === -1)
+      continue
+
+    const key = line.slice(0, equalIndex).trim()
+    if (!keys.has(key))
+      continue
+
+    const value = line.slice(equalIndex + 1).trim().replace(/^['"]|['"]$/g, '')
+    if (value)
+      process.env[key] = value
+  }
+}
+
+loadLocalGitHubEnv()
+
 const isAliyunESA = Boolean(process.env.AliUid)
 const isTencentEdgeOne = process.env.HOME === '/dev/shm/home' && process.env.TMPDIR === '/dev/shm/tmp'
 


### PR DESCRIPTION
## 变更内容

在复制 Markdown 为微信/知乎格式前，自动扫描本地图片并上传至 GitHub + jsDelivr CDN，替换图片 URL。

### 新增文件
- \src/storage/github-storage.ts\: GitHub 存储提供者，基于 node:https + GitHub Content API
- \src/storage/types.ts\: 增加 \github\ 存储类型，UploadOptions.file 支持 Blob | Buffer
- \src/routes/api.upload.github-images.ts\: POST API 路由，读取本地文件上传到 GitHub
- \src/lib/actions/check-local-images.ts\: Markdown 扫描器 findLocalImagesInMarkdown / replaceImageUrlsInMarkdown
- \src/components/dialog/image-upload-dialog.tsx\: 上传确认弹窗
- \src/stores/image-upload.ts\: Zustand store + Promise 模式管理上传状态
- \src/services/upload-local-images.ts\: 客户端上传服务

### 修改文件
- \ite.config.ts\: 启动时从 .env 加载 GitHub 配置，防止 shell 环境变量覆盖
- \src/env/index.ts\: getPrivate() 加 .trim() 防御 CRLF 换行符问题
- \src/lib/actions/copy-platform.ts\: 复制前检测本地图片，上传后直接渲染最新内容
- \src/routes/_layout.tsx\: 添加 ImageUploadDialog 组件
- \src/storage/index.ts\: 导出 GitHubStorage
- \.env.example\: 添加 GitHub 图床配置文档

### 修复
- 大图片（>7MB）通过 Buffer 编码，避免 String.fromCodePoint 爆栈
- 本地路径检测：无协议头的路径视为本地图片
- 环境变量 CRLF 问题：Windows 下 .env 的 \\r 不干扰认证

### 使用方式
1. 在 .env 中配置 GITHUB_TOKEN、GITHUB_OWNER、GITHUB_REPO
2. 点击编辑器工具栏的「复制为微信格式」
3. 弹出确认框，点击「上传并复制」
4. 图片自动上传至 GitHub CDN（jsDelivr），URL 替换后复制到剪贴板